### PR TITLE
Exclude Attached to

### DIFF
--- a/00-grow-disk-online
+++ b/00-grow-disk-online
@@ -106,7 +106,7 @@ disk_uuid="${!var_name_uuid}"
 disk_id_short="${disk_uuid%%-*}"
 
 # let's see if we can find one matching disk
-disk_id_qemu_line=`echo "info block" | ${SOCAT_COMMAND} | grep -F ${disk_id_short}`
+disk_id_qemu_line=`echo "info block" | ${SOCAT_COMMAND} | grep -F ${disk_id_short} | grep -v "Attached to"`
 [[ $(echo "${disk_id_qemu_line}" | wc -l) -eq 1 ]] || log_fail "found more then one disk that match ${disk_id_short}"
 disk_id_qemu=`echo "${disk_id_qemu_line}" | cut -d':' -f1 | cut -d' ' -f1`
 log_info "attempting to resize ${GANETI_INSTANCE_NAME} disk IDX=${GANETI_DISK} UUID=${disk_uuid} qemu-ID=${disk_id_qemu} from ${old_size}MiB to ${new_size}MiB"


### PR DESCRIPTION
Excluding the Attached to line to avoid the "found more then one disk that match" error on line 110

Result when not excluding the attached to line:
```bash
xen03-rya.ops:/home/users/ryant# SOCAT_COMMAND="timeout 10s socat STDIO UNIX-CONNECT:/var/run/ganeti/kvm-hypervisor/ctrl/upgrade02-rya.ops.monitor"
xen03-rya.ops:/home/users/ryant# echo "info block" | ${SOCAT_COMMAND} | grep -F "d6c0b32f"
disk-d6c0b32f-9001-4bb1 (#block130): /var/run/ganeti/instance-disks/upgrade02-rya.ops:0 (raw)
    Attached to:      /machine/peripheral/disk-d6c0b32f-9001-4bb1/virtio-backend
xen03-rya.ops:/home/users/ryant#
```

Result when excluding the attached to line:
```bash
xen03-rya.ops:/home/users/ryant# echo "info block" | ${SOCAT_COMMAND} | grep -F "d6c0b32f" | grep -v "Attached to"
disk-d6c0b32f-9001-4bb1 (#block130): /var/run/ganeti/instance-disks/upgrade02-rya.ops:0 (raw)
```

Test results after making this change:
```bash
xen03-rya.ops:/home/users/ryant# vi grow-disk-online
xen03-rya.ops:/home/users/ryant# install -o root -g root -m 0700 /home/users/ryant/grow-disk-online /etc/ganeti/hooks/disk-grow-post.d/50-grow-disk-online
xen03-rya.ops:/home/users/ryant# gnt-cluster copyfile /etc/ganeti/hooks/disk-grow-post.d/50-grow-disk-online
xen03-rya.ops:/home/users/ryant# gnt-instance grow-disk upgrade02-rya.ops 0 2G
Wed Jul 20 14:12:34 2022 Growing disk 0 of instance 'upgrade02-rya.ops' by 2.0G to 20.0G
Wed Jul 20 14:12:35 2022  - INFO: Waiting for instance upgrade02-rya.ops to sync disks
Wed Jul 20 14:12:35 2022  - INFO: Instance upgrade02-rya.ops's disks are in sync
xen03-rya.ops:/home/users/ryant#
```